### PR TITLE
dashboard fix

### DIFF
--- a/apps/web/src/components/pages/dashboard/dashboardCards.jsx
+++ b/apps/web/src/components/pages/dashboard/dashboardCards.jsx
@@ -97,53 +97,71 @@ const DashboardCards = () => {
                   sx={{ "&:last-child td, &:last-child th": { border: 0 } }}
                 >
                   <TableCell>{item.service}</TableCell>
-                  {item.environments.map((env) => (
-                    <TableCell key={env._id} align="right">
-                      {env.version}
-                      <br />
-                      {(() => {
-                        if (env.status === "Deployed") {
-                          return (
-                            <Chip
-                              label={env.status}
-                              color="success"
-                              variant="outlined"
-                              size="small"
-                            />
-                          );
-                        } else if (env.status === "Deploying") {
-                          return (
-                            <Chip
-                              label={env.status}
-                              color="primary"
-                              variant="outlined"
-                              size="small"
-                            />
-                          );
-                        } else if (env.status === "Failed") {
-                          return (
-                            <Chip
-                              label={env.status}
-                              color="error"
-                              variant="outlined"
-                              size="small"
-                            />
-                          );
-                        } else {
-                          return (
-                            <Chip
-                              label={env.status}
-                              color="secondary"
-                              variant="outlined"
-                              size="small"
-                            />
-                          );
-                        }
-                      })()}
-                      <br />
-                      {tzConvert(env.timestamp)}
-                    </TableCell>
-                  ))}
+                  {environments.map((envName) => {
+                    // Find the matching environment data for this service
+                    const env = item.environments.find(
+                      (e) => e.name === envName
+                    );
+                    
+                    return (
+                      <TableCell key={envName} align="right">
+                        {env ? (
+                          <>
+                            {env.version}
+                            <br />
+                            {(() => {
+                              if (env.status === "Deployed") {
+                                return (
+                                  <Chip
+                                    label={env.status}
+                                    color="success"
+                                    variant="outlined"
+                                    size="small"
+                                  />
+                                );
+                              } else if (env.status === "Deploying") {
+                                return (
+                                  <Chip
+                                    label={env.status}
+                                    color="primary"
+                                    variant="outlined"
+                                    size="small"
+                                  />
+                                );
+                              } else if (env.status === "Failed") {
+                                return (
+                                  <Chip
+                                    label={env.status}
+                                    color="error"
+                                    variant="outlined"
+                                    size="small"
+                                  />
+                                );
+                              } else {
+                                return (
+                                  <Chip
+                                    label={env.status}
+                                    color="secondary"
+                                    variant="outlined"
+                                    size="small"
+                                  />
+                                );
+                              }
+                            })()}
+                            <br />
+                            {tzConvert(env.timestamp)}
+                          </>
+                        ) : (
+                          <Chip
+                            label="No Data"
+                            color="default"
+                            variant="outlined"
+                            size="small"
+                          />
+                        )}
+                      </TableCell>
+                    );
+                  })}
                 </TableRow>
               ))
             : null}


### PR DESCRIPTION
## Description

Please include a summary of the change and which issue this closes. Please also include relevant motivation and context.

closes #41

- Fixed dashboard column alignment by iterating over the full environments list instead of each service's individual environment data, using `.find()` to match deployment data by environment name. When a service doesn't have deployment data for an environment, a "No Data" chip is displayed to maintain proper column alignment.

---

### Dependencies

List any dependencies that are required for this change that may need attention before merging this PR.

None

---

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. Screenshots are always helpful.

Locally

<img width="1505" height="708" alt="image" src="https://github.com/user-attachments/assets/2f90b31b-d6a3-4c1b-978e-317f8f743f92" />


---

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] I have performed a self-review of my own code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] My changes generate no new warnings or errors.
- [x] Any dependent changes have been merged and published.
