### PR TITLE
Session Duration and password setting enforcement

### DIFF
--- a/apps/auth/src/routes/login.js
+++ b/apps/auth/src/routes/login.js
@@ -1,7 +1,7 @@
 import express from "express";
 import log from "loglevel";
 
-import { User } from "models";
+import { User, Account } from "models";
 import { sendLockedMail } from "../utils/sendMail.js";
 import { generateToken } from "../utils/token.js";
 
@@ -51,8 +51,10 @@ router.route("/").post(async (req, res) => {
     
     if (isMatch) {
       log.debug("Passwords match");
+      // fetch account to get sessionDuration
+      const account = await Account.findOne({ name: user.account });
       // generate a token for the user
-      const token = generateToken(user);
+      const token = generateToken(user, account.sessionDuration);
       log.debug("Token generated");
       log.debug(token);
       // reset attempts and lockUntil

--- a/apps/auth/src/routes/sso.js
+++ b/apps/auth/src/routes/sso.js
@@ -204,13 +204,16 @@ router.route("/callback").post(async (req, res) => {
 
     log.debug("userRole:", userRole);
 
-    // generate a token
-    const token = generateToken({
-      id: uid,
+    // construct user object for token generation
+    const user = {
+      _id: uid,
       email: email,
       role: userRole,
       account: accountName,
-    });
+    };
+
+    // generate a token
+    const token = generateToken(user, account.sessionDuration);
     log.debug("Token generated");
     log.debug(token);
 

--- a/apps/auth/src/utils/token.js
+++ b/apps/auth/src/utils/token.js
@@ -2,7 +2,7 @@ import jwt from "jsonwebtoken";
 import dotenv from "dotenv";
 dotenv.config();
 
-const generateToken = (user) => {
+const generateToken = (user, sessionDuration = 8) => {
   return jwt.sign(
     {
       id: user._id,
@@ -12,7 +12,7 @@ const generateToken = (user) => {
     },
     process.env.ACCESS_TOKEN_SECRET,
     {
-      expiresIn: "8h",
+      expiresIn: `${sessionDuration}h`,
     }
   );
 };

--- a/apps/web/src/App.jsx
+++ b/apps/web/src/App.jsx
@@ -19,6 +19,7 @@ import Users from "./components/pages/account/users/users";
 import ApiKeys from "./components/pages/account/apikeys/apikeys";
 import SSOConfig from "./components/pages/account/sso/ssoConfig";
 import Integrations from "./components/pages/account/integrations/integrations";
+import AccountSettings from "./components/pages/account/accountSettings/accountSettings";
 import Settings from "./components/pages/settings/settings";
 import NotFound from "./components/pages/notFound/notFound";
 import Logout from "./components/pages/logout/logout";
@@ -57,6 +58,7 @@ const App = () => {
           <Route path="/account/apikeys" element={<ApiKeys />} />
           <Route path="/account/sso" element={<SSOConfig />} />
           <Route path="/account/integrations" element={<Integrations />} />
+          <Route path="/account/settings" element={<AccountSettings />} />
           <Route path="/settings" element={<Settings />} />
           <Route path="/logout" element={<Logout />} />
           <Route path="/" element={<Navigate to="/dashboard" replace />} />

--- a/apps/web/src/components/pages/account/accountSettings/accountSettings.jsx
+++ b/apps/web/src/components/pages/account/accountSettings/accountSettings.jsx
@@ -1,0 +1,334 @@
+import { useState, useEffect } from "react";
+import axios from "axios";
+import {
+  Box,
+  Typography,
+  Paper,
+  TextField,
+  Button,
+  Alert,
+  Snackbar,
+  Grid,
+  Divider,
+  FormHelperText,
+} from "@mui/material";
+import CssBaseline from "@mui/material/CssBaseline";
+import MiniDrawer from "../../../structure/headerDrawer";
+import { getToken } from "../../../utils/auth";
+
+const AccountSettings = () => {
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState("");
+  const [success, setSuccess] = useState("");
+
+  // Account settings fields
+  const [sessionDuration, setSessionDuration] = useState(null);
+  const [passwordPolicy, setPasswordPolicy] = useState(null);
+
+  useEffect(() => {
+    fetchAccountData();
+  }, []);
+
+  const fetchAccountData = async () => {
+    try {
+      const res = await axios.get(`${import.meta.env.VITE_API_URI}/accounts`, {
+        headers: {
+          Authorization: `Bearer ${getToken()}`,
+        },
+      });
+      console.log("Fetched account data:", res.data);
+      setSessionDuration(res.data.sessionDuration);
+      setPasswordPolicy(res.data.passwordPolicy);
+      setLoading(false);
+    } catch (err) {
+      console.error("Fetch error:", err);
+      setError("Failed to load account settings");
+      setLoading(false);
+    }
+  };
+
+  const handleSaveSessionDuration = async () => {
+    setSaving(true);
+    setError("");
+    setSuccess("");
+
+    // Validation
+    const duration = parseInt(sessionDuration);
+    if (isNaN(duration) || duration < 1 || duration > 720) {
+      setError("Session duration must be between 1 and 720 hours");
+      setSaving(false);
+      return;
+    }
+
+    try {
+      await axios.post(
+        `${import.meta.env.VITE_API_URI}/accounts`,
+        {
+          sessionDuration: duration,
+        },
+        {
+          headers: {
+            Authorization: `Bearer ${getToken()}`,
+          },
+        }
+      );
+
+      setSuccess(
+        "Session duration updated successfully. Changes will apply to new logins."
+      );
+    } catch (err) {
+      setError(err.response?.data?.message || err.message);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleSavePasswordPolicy = async () => {
+    setSaving(true);
+    setError("");
+    setSuccess("");
+
+    // Validate password policy
+    if (passwordPolicy.length < 8 || passwordPolicy.length > 128) {
+      setError("Password length must be between 8 and 128 characters");
+      setSaving(false);
+      return;
+    }
+
+    if (passwordPolicy.lowercase < 0 || passwordPolicy.uppercase < 0 || 
+        passwordPolicy.number < 0 || passwordPolicy.special < 0) {
+      setError("Character requirements cannot be negative");
+      setSaving(false);
+      return;
+    }
+
+    // Validate that total requirements don't exceed length
+    const totalRequired = 
+      passwordPolicy.lowercase + 
+      passwordPolicy.uppercase + 
+      passwordPolicy.number + 
+      passwordPolicy.special;
+    
+    if (totalRequired > passwordPolicy.length) {
+      setError(
+        `Total character requirements (${totalRequired}) cannot exceed password length (${passwordPolicy.length})`
+      );
+      setSaving(false);
+      return;
+    }
+
+    try {
+      await axios.post(
+        `${import.meta.env.VITE_API_URI}/accounts`,
+        {
+          passwordPolicy,
+        },
+        {
+          headers: {
+            Authorization: `Bearer ${getToken()}`,
+          },
+        }
+      );
+
+      setSuccess(
+        "Password policy updated successfully. Changes will apply to new passwords."
+      );
+    } catch (err) {
+      setError(err.response?.data?.message || err.message);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleCloseSnackbar = () => {
+    setError("");
+    setSuccess("");
+  };
+
+  const convertToDays = (hours) => {
+    const days = Math.floor(hours / 24);
+    const remainingHours = hours % 24;
+    if (days === 0) {
+      return `${hours} hour${hours !== 1 ? "s" : ""}`;
+    }
+    if (remainingHours === 0) {
+      return `${days} day${days !== 1 ? "s" : ""}`;
+    }
+    return `${days} day${days !== 1 ? "s" : ""} and ${remainingHours} hour${remainingHours !== 1 ? "s" : ""}`;
+  };
+
+  if (loading) {
+    return (
+      <Box sx={{ display: "flex" }}>
+        <CssBaseline />
+        <MiniDrawer />
+        <Box component="main" sx={{ flexGrow: 1, p: 3 }}>
+          <Typography>Loading...</Typography>
+        </Box>
+      </Box>
+    );
+  }
+
+  return (
+    <Box sx={{ display: "flex" }}>
+      <CssBaseline />
+      <MiniDrawer />
+      <Box component="main" sx={{ flexGrow: 1, p: 3 }}>
+        <Typography variant="h6" sx={{ pb: 2 }}>
+          Account Settings
+        </Typography>
+
+        <Grid container spacing={3}>
+          <Grid size={{ xs: 12, md: 6 }}>
+            <Paper sx={{ p: 3 }}>
+              <Typography variant="h6" sx={{ mb: 2 }}>
+                Session Duration
+              </Typography>
+          <Divider sx={{ mb: 2 }} />
+
+          <TextField
+            label="Session Duration (hours)"
+            type="number"
+            value={sessionDuration}
+            onChange={(e) => setSessionDuration(e.target.value)}
+            fullWidth
+            margin="normal"
+            inputProps={{
+              min: 1,
+              max: 720,
+              step: 1,
+            }}
+            helperText={`Current value: ${convertToDays(sessionDuration)}. Valid range: 1 hour to 720 hours (30 days).`}
+          />
+
+          <FormHelperText sx={{ mt: 1, mb: 2 }}>
+            Session duration determines how long users can stay logged in before
+            they need to re-authenticate. Changes will apply to new logins only.
+          </FormHelperText>
+
+          <Button
+            variant="contained"
+            onClick={handleSaveSessionDuration}
+            disabled={saving}
+            sx={{ mt: 2 }}
+          >
+            {saving ? "Saving..." : "Save Session Duration"}
+          </Button>
+            </Paper>
+          </Grid>
+
+          <Grid size={{ xs: 12, md: 6 }}>
+            <Paper sx={{ p: 3 }}>
+              <Typography variant="h6" sx={{ mb: 2 }}>
+                Password Policy
+              </Typography>
+          <Divider sx={{ mb: 2 }} />
+
+          <TextField
+            label="Minimum Password Length"
+            type="number"
+            value={passwordPolicy.length}
+            onChange={(e) => setPasswordPolicy({...passwordPolicy, length: parseInt(e.target.value) || 8})}
+            fullWidth
+            margin="normal"
+            inputProps={{
+              min: 8,
+              max: 128,
+              step: 1,
+            }}
+            helperText="Minimum 8, maximum 128 characters"
+          />
+
+          <TextField
+            label="Minimum Lowercase Letters"
+            type="number"
+            value={passwordPolicy.lowercase}
+            onChange={(e) => setPasswordPolicy({...passwordPolicy, lowercase: parseInt(e.target.value) || 0})}
+            fullWidth
+            margin="normal"
+            inputProps={{
+              min: 0,
+              step: 1,
+            }}
+            helperText="Minimum number of lowercase letters required (a-z)"
+          />
+
+          <TextField
+            label="Minimum Uppercase Letters"
+            type="number"
+            value={passwordPolicy.uppercase}
+            onChange={(e) => setPasswordPolicy({...passwordPolicy, uppercase: parseInt(e.target.value) || 0})}
+            fullWidth
+            margin="normal"
+            inputProps={{
+              min: 0,
+              step: 1,
+            }}
+            helperText="Minimum number of uppercase letters required (A-Z)"
+          />
+
+          <TextField
+            label="Minimum Numbers"
+            type="number"
+            value={passwordPolicy.number}
+            onChange={(e) => setPasswordPolicy({...passwordPolicy, number: parseInt(e.target.value) || 0})}
+            fullWidth
+            margin="normal"
+            inputProps={{
+              min: 0,
+              step: 1,
+            }}
+            helperText="Minimum number of numeric digits required (0-9)"
+          />
+
+          <TextField
+            label="Minimum Special Characters"
+            type="number"
+            value={passwordPolicy.special}
+            onChange={(e) => setPasswordPolicy({...passwordPolicy, special: parseInt(e.target.value) || 0})}
+            fullWidth
+            margin="normal"
+            inputProps={{
+              min: 0,
+              step: 1,
+            }}
+            helperText="Minimum number of special characters required (!@#$%^&*, etc.)"
+          />
+
+          <FormHelperText sx={{ mt: 2, mb: 2 }}>
+            Password policy settings will apply to new passwords and password changes.
+            Existing passwords will not be affected until users change them.
+          </FormHelperText>
+
+          <Button
+            variant="contained"
+            onClick={handleSavePasswordPolicy}
+            disabled={saving}
+            sx={{ mt: 2 }}
+          >
+            {saving ? "Saving..." : "Save Password Policy"}
+          </Button>
+            </Paper>
+          </Grid>
+        </Grid>
+
+        <Snackbar
+          open={!!error || !!success}
+          autoHideDuration={6000}
+          onClose={handleCloseSnackbar}
+        >
+          <Alert
+            onClose={handleCloseSnackbar}
+            severity={error ? "error" : "success"}
+            sx={{ width: "100%" }}
+          >
+            {error || success}
+          </Alert>
+        </Snackbar>
+      </Box>
+    </Box>
+  );
+};
+
+export default AccountSettings;

--- a/apps/web/src/components/pages/login/login.jsx
+++ b/apps/web/src/components/pages/login/login.jsx
@@ -165,6 +165,8 @@ const Login = () => {
                       <IconButton
                         aria-label="Toggle password visibility"
                         onClick={handleClickShowPassword}
+                        edge="end"
+                        tabIndex={-1}
                       >
                         {showPassword ? (
                           <VisibilityOffRoundedIcon />

--- a/apps/web/src/components/structure/headerDrawer.jsx
+++ b/apps/web/src/components/structure/headerDrawer.jsx
@@ -20,6 +20,7 @@ import ForestIcon from "@mui/icons-material/Forest";
 import PeopleAltIcon from "@mui/icons-material/PeopleAlt";
 import VpnKeyIcon from "@mui/icons-material/VpnKey";
 import MemoryIcon from "@mui/icons-material/Memory";
+import AdminPanelSettingsIcon from "@mui/icons-material/AdminPanelSettings";
 import LogoutIcon from "@mui/icons-material/Logout";
 import SettingsIcon from "@mui/icons-material/Settings";
 
@@ -40,6 +41,11 @@ const adminPages = [
   { name: "Users", icon: <PeopleAltIcon /> },
   { name: "ApiKeys", icon: <VpnKeyIcon /> },
   { name: "SSO", icon: <MemoryIcon /> },
+  {
+    name: "Account Settings",
+    icon: <AdminPanelSettingsIcon />,
+    path: "/account/settings",
+  },
 ];
 
 const openedMixin = (theme) => ({
@@ -192,7 +198,7 @@ const MiniDrawer = () => {
               >
                 <ListItemButton
                   component={Link}
-                  to={`/account/${item.name.toLowerCase()}`}
+                  to={item.path || `/account/${item.name.toLowerCase()}`}
                   sx={{
                     minHeight: 48,
                     justifyContent: open ? "initial" : "center",

--- a/packages/models/src/account.js
+++ b/packages/models/src/account.js
@@ -68,6 +68,13 @@ const AccountSchema = new mongoose.Schema(
       type: Object,
       required: false,
     },
+    sessionDuration: {
+      type: Number,
+      required: true,
+      default: 8,
+      min: 1,
+      max: 720, // 30 days * 24 hours
+    },
   },
   {
     collection: "accounts",


### PR DESCRIPTION
## Description

Please include a summary of the change and which issue this closes. Please also include relevant motivation and context.

closes #39

#### Session Management & Account Settings

- Added configurable session token duration (1-720 hours) to Account model with validation
- Updated JWT token generation to use account-specific session duration in both login and SSO flows
- Created admin Account Settings page with session duration and password policy configuration UI

#### Password Policy Enforcement

- Implemented backend password policy validation in `/me` endpoint with regex-based character counting
- Added real-time password validation in user settings with visual feedback (red highlighting on invalid fields)
- Display password requirements dynamically based on account policy

#### UX Improvements

- Disable "Change Password" button when form is invalid or passwords don't match
- Real-time validation with `onBlur` handlers and immediate feedback when typing
- Clear validation errors reactively as user corrects input
- Remove password visibility toggle buttons from tab order (`tabIndex={-1}`) for better security/accessibility
- Added admin-only "Account Settings" menu item in navigation drawer

#### Data Model

- Added `sessionDuration` field to Account schema (required, default: 8 hours, range: 1-720)
- Password policy stored as nested schema with configurable character requirements
- Eliminated hardcoded fallback values throughout codebase, rely on schema defaults


---

### Dependencies

List any dependencies that are required for this change that may need attention before merging this PR.

None

---

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. Screenshots are always helpful.

Locally

---

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] I have performed a self-review of my own code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] My changes generate no new warnings or errors.
- [x] Any dependent changes have been merged and published.
